### PR TITLE
Move search/filter to server side.

### DIFF
--- a/src/app/api/advocates/route.ts
+++ b/src/app/api/advocates/route.ts
@@ -1,12 +1,33 @@
-import db from "../../../db";
+import { NextRequest } from "next/server";
+import db, { DbType } from "../../../db";
 import { advocates } from "../../../db/schema";
 import { advocateData } from "../../../db/seed/advocates";
+import { ilike, or } from "drizzle-orm";
 
-export async function GET() {
+export async function GET(req: NextRequest) {
   // Uncomment this line to use a database
-  const data = await db.select().from(advocates);
 
-  //const data = advocateData;
+  
+  const search = req.nextUrl.searchParams.get('search');
+  const wildcard = `%${search}%`;
+  
+  const dbReq = db.select().from(advocates);
+
+  // there is no easy way to query specialites -- I would suggest putting them in another table
+  // but that's outside of the scope for now.
+  const dbReqWithWhere = 
+  (search ?? "").length > 0 ? 
+    dbReq.where(
+      or(
+        ilike(advocates.firstName, wildcard),
+        ilike(advocates.lastName, wildcard),
+        ilike(advocates.city, wildcard)
+        // can add more fields here...
+      )
+    ) :
+    dbReq;
+
+  const data = await dbReqWithWhere;
 
   return Response.json({ data });
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,7 +6,6 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 export default function Home() {
   const [advocates, setAdvocates] = useState<Advocate[]>([]);
-  const [filteredAdvocates, setFilteredAdvocates] = useState<Advocate[]>([]);
   const searchRef = useRef<HTMLInputElement | null>(null); // we may no longer need this
   const searchTimer = useRef<NodeJS.Timeout| undefined>(undefined);
 
@@ -17,33 +16,14 @@ export default function Home() {
 
   useEffect(() => {
     console.log("fetching advocates...");
-    fetch("/api/advocates").then((response) => {
+    const url = "/api/advocates?search=" + encodeURIComponent(effectiveSearchText);
+    fetch(url).then((response) => {
       response.json().then((json) => {
         AdvocateArraySchema.parseAsync(json).then((advocates) => {
           setAdvocates(advocates.data ?? []);
-          setFilteredAdvocates(advocates.data ?? []);
         });
       });
     });
-  }, []);
-
-  useEffect(() => {
-    if (effectiveSearchText.length === 0) {
-      setFilteredAdvocates(advocates);
-      return;
-    }
-    const filteredAdvocates = advocates.filter((advocate) => {
-      return (
-        advocate.firstName.includes(effectiveSearchText) ||
-        advocate.lastName.includes(effectiveSearchText) ||
-        advocate.city.includes(effectiveSearchText) ||
-        advocate.degree.includes(effectiveSearchText) ||
-        advocate.specialties.includes(effectiveSearchText)
-      );
-    });
-
-    setFilteredAdvocates(filteredAdvocates);
-
   }, [effectiveSearchText]);
 
   const performSearch = useCallback(() => {
@@ -83,7 +63,7 @@ export default function Home() {
       <table>
         <AdvocateHeader />
         <tbody>
-          {filteredAdvocates.map((advocate) => {
+          {advocates.map((advocate) => {
             return (
               <tr>
                 <td>{advocate.firstName}</td>

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -2,14 +2,15 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 
 const setup = () => {
-  if (!process.env.DATABASE_URL) {
-    console.error("DATABASE_URL is not set");
-    return {
-      select: () => ({
-        from: () => [],
-      }),
-    };
-  }
+  // commenting this out makes typescript happier about the type of db.
+  // if (!process.env.DATABASE_URL) {
+  //   console.error("DATABASE_URL is not set");
+  //   return {
+  //     select: () => ({
+  //       from: () => [],
+  //     }),
+  //   };
+  // }
 
   // for query purposes
   const queryClient = postgres(process.env.DATABASE_URL);


### PR DESCRIPTION
Search/filter now happens on server side and we only send over matching advocates. This breaks matching on specialties -- fixing that would requiring rethinking the schema (putting them in a separate table).